### PR TITLE
new footer w/ links

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -4,43 +4,45 @@
   <!-- Contact -->
   <div class="col-xs-12 col-sm-2 col-footer">
     <p>Contact<br/>
-      <a href="#">Contact Form</a><br/>
-      <a href="#">Library Departments</a><br/>
-      <a href="#">Staff Directory</a><br/>
+      <a href="https://www.lib.uchicago.edu/research/help/ask-librarian/ask-contact/">Contact Form</a><br/>
+      <a href="https://www.lib.uchicago.edu/about/directory/?view=department">Library Departments</a><br/>
+      <a href="https://www.lib.uchicago.edu/about/directory/?view=staff">Staff Directory</a><br/>
     </p>
   </div>
   <!-- // Contact -->
 
   <!-- Information -->
   <div class="col-xs-12 col-sm-2 col-footer divider-vertical">
-    <p>Information for<br/>
-      <a href="#">Faculty</a><br/>
-      <a href="#">Students</a><br/>
-      <a href="#">University Staff</a><br/>
-      <a href="#">Visitors</a><br/>
-      <a href="#">Alumni &amp; Library Friends</a><br/>
-      <a href="#">Patrons with Disabilities</a>
+    <p>Policies<br/>
+      <a href="https://www.lib.uchicago.edu/research/help/infofor/accessibility/">Patrons with Disabilities</a><br/>
+      <a href="https://www.lib.uchicago.edu/about/thelibrary/policies/">Library Policies</a><br/>
+      <a href="https://www.lib.uchicago.edu/about/thelibrary/policies/privacy/">Privacy Statement</a><br/>
+      <a href="https://accessibility.uchicago.edu/">University Accessibility</a><br/>
     </p>
   </div><!-- // Information -->
 
   <!-- Libraries -->
   <div class="col-xs-12 col-sm-2 col-footer col-sm-push-4 divider-vertical">
     <p>Libraries<br/>
-      <a href="#">Crerar</a><br/>
-      <a href="#">D’Angelo Law</a><br/>
-      <a href="#">Eckhart</a><br/>
-      <a href="#">Mansueto</a><br/>
-      <a href="#">Regenstein</a><br/>
-      <a href="#">SSA</a>
+      <a href="https://www.lib.uchicago.edu/crerar/">Crerar</a><br/>
+      <a href="https://www.lib.uchicago.edu/law/">D’Angelo Law</a><br/>
+      <a href="https://www.lib.uchicago.edu/eck/">Eckhart</a><br/>
+      <a href="https://www.lib.uchicago.edu/mansueto/">Mansueto</a><br/>
+      <a href="https://www.lib.uchicago.edu/spaces/joseph-regenstein-library/">Regenstein</a><br/>
+      <a href="https://www.lib.uchicago.edu/scrc/">Special Collections</a><br/>
+      <a href="https://www.lib.uchicago.edu/swl/">Social Work</a><br/>
     </p>
   </div><!-- // Libraries -->
 
   <!-- Social -->
   <div class="col-xs-12 col-sm-2 col-footer col-sm-push-4">
     <p>Library Social Media<br/>
-      <a href="#"><i class="fa fa-facebook-official"></i> &nbsp; Facebook</a><br/>
-      <a href="#"><i class="fa fa-rss-square"></i> &nbsp; Library News</a><br/>
-      <a href="#"><i class="fa fa-clone"></i> &nbsp; More Library Accounts...</a>
+	<a href="http://www.facebook.com/uchicagolibrary"><i class="fa fa-facebook-official"></i> &nbsp; Facebook</a><br/>
+	<a href="https://twitter.com/UChicagoLibrary"><i class="fa fa-twitter"></i> &nbsp; Twitter</a><br/>
+	<a href="https://www.instagram.com/uchicagolibrary/"><i class="fa fa-instagram"></i> &nbsp; Instagram</a><br/>
+	<a href="http://news.lib.uchicago.edu/"><i class="fa fa-rss-square"></i> &nbsp; Library News</a><br/>
+	<a href="https://www.youtube.com/user/uchicagolibrary"><i class="fa fa-youtube-square"></i> &nbsp; Library News</a><br/>
+	<a href="https://www.lib.uchicago.edu/about/news-events/social-media/"><i class="fa fa-clone"></i> &nbsp; More Library Accounts...</a><br/>
     </p>
   </div><!-- // Social -->
 


### PR DESCRIPTION
Fixes #15, replacing stub links with the Wagtail links.  

Note that this PR collapses "Information" and "Policies" into one section, just as a time-saving measure.  At a later time, if we want, we can write up an issue to redo the footer so that it is exactly the way it is in Wagtail, though that will involve putting more logic into the site's CSS.