### PR TITLE
Update cgimail surrogates to test forms

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,17 +41,20 @@ def inject_dict():
     return {
         'cnet_id' : cnetid,
         'cgimail' : {
+            'default' : {
+                'from' : 'Vitor G <vitorg@uchicago.edu>'
+            },
             'request_access': {
                 'rcpt': 'askscrc',
-                'subject': 'Request for an Account for MLC',
+                'subject': '[TEST] Request access for MLC series',
             },
             'request_account': {
                 'rcpt': 'askscrc',
-                'subject': 'Request access for MLC series',
+                'subject': '[TEST] Request for an Account for MLC',
             }, 
             'feedback': {
-                'rcpt': 'askscrc',
-                'subject': 'Feedback about Mesoamerican Language Collection Portal',
+                'rcpt': 'vitor',
+                'subject': '[TEST] Feedback about Mesoamerican Language Collection Portal',
             }, 
         },
         'locale': get_locale(),

--- a/app.py
+++ b/app.py
@@ -46,11 +46,11 @@ def inject_dict():
             },
             'request_access': {
                 'rcpt': 'askscrc',
-                'subject': '[TEST] Request access for MLC series',
+                'subject': '[TEST] Request for access to MLC restricted series',
             },
             'request_account': {
                 'rcpt': 'askscrc',
-                'subject': '[TEST] Request for an Account for MLC',
+                'subject': '[TEST] Request for MLC account',
             }, 
             'feedback': {
                 'rcpt': 'vitor',

--- a/templates/request-account.html
+++ b/templates/request-account.html
@@ -6,8 +6,13 @@
     <h1>{% trans %}Request Account for Access{% endtrans %}</h1>
   </div>
         <p style="max-width: 600px">
-          {% trans %}This form allows visitors without a UChicago ID to request an account with specific privileges to access the contents of the Mesoamerican Language Collection Portal that might be of controlled access. For more information visit <a href="/access-terms">/access-terms</a>.{% endtrans %}<br>
-          {% trans %}Please provide a brief summary of the purpose for your access. Account requests are analyzed on a case-by-case basis, and take typically 1 week to be processed.{% endtrans %}
+          {% trans %}This form allows visitors without a UChicago ID to request an account with specific privileges to access the contents of the Mesoamerican Language Collection Portal that might be of controlled access. For more information visit <a href="/access-terms">/access-terms</a>.{% endtrans %}
+        </p>
+        <p style="max-width: 600px">
+          {% trans %}Please provide a brief summary of the purpose for your access. Account requests are analyzed on a case-by-case basis, and can typically be created within five business days.{% endtrans %}
+        </p>
+        <p style="max-width: 600px">
+          {% trans %}After it is created, to use an account requires installation of the University’s two-factor authentication (2FA) service.{% endtrans %}
         </p>
   <form class="gray-surface" action="https://www.lib.uchicago.edu/cgi-bin/cgimail" method="POST" style="max-width: 600px">
     <div class="row">

--- a/templates/request-account.html
+++ b/templates/request-account.html
@@ -14,20 +14,20 @@
       <div class="col-xs-12">
         <input type="hidden" name="rcpt" value="{{cgimail.request_account.rcpt}}">
         {# <input type="hidden" name="whom" value="MLC website"> #}
-        <input type="hidden" name="from" value="MLC website">
+        <input type="hidden" id="cgimailfrom" name="from" value="{{cgimail.default.from}}">
         {# <input type="hidden" name="vrfy" value="trivial"> #}
         <input type="hidden" name="subject" value="{{cgimail.request_account.subject}}">
         <div class="form-group">
           <label for="name">{% trans %}Name{% endtrans %}*</label>
-          <input type="text" class="form-control" id="name" name="Name" placeholder="{% trans %}Enter your name{% endtrans %}" required>
+          <input type="text" class="form-control" id="name" name="User's Name" placeholder="{% trans %}Enter your name{% endtrans %}" required>
         </div>
         <div class="form-group">
           <label for="email">{% trans %}Email address{% endtrans %}*</label>
-          <input type="email" class="form-control" id="Email" name="email" placeholder="{% trans %}Enter your email address{% endtrans %}" required>
+          <input type="email" class="form-control" id="Email" name="User's Email" placeholder="{% trans %}Enter your email address{% endtrans %}" required onchange="document.getElementById('cgimailfrom').value =(this.value)">
         </div>
         <div class="form-group">
           <label for="birthday">{% trans %}Birthday{% endtrans %}*</label>
-          <input type="date" class="form-control" id="birthday" name="Birthday" value="2005-01-01" required>
+          <input type="date" class="form-control" id="birthday" name="User's Birthday" value="2005-01-01" required>
         </div>
         <div class="form-group">
           <label for="projectDescription">{% trans %}Please describe your research project{% endtrans %}</label>

--- a/templates/request-account.html
+++ b/templates/request-account.html
@@ -5,11 +5,11 @@
   <div class="title-wrapper">
     <h1>{% trans %}Request Account for Access{% endtrans %}</h1>
   </div>
-        <p>
-          {% trans %}This form allows visitors without a UChicago ID to request an account with specific privileges to access the contents of the Mesoamerican Language Collection Portal that might be of controlled access. For more information visit /access-terms.
-          Please provide a brief summary of the purpose for your access. Account requests are analyzed on a case-by-case basis, and take typically 1 week to be processed.{% endtrans %}
+        <p style="max-width: 600px">
+          {% trans %}This form allows visitors without a UChicago ID to request an account with specific privileges to access the contents of the Mesoamerican Language Collection Portal that might be of controlled access. For more information visit <a href="/access-terms">/access-terms</a>.{% endtrans %}<br>
+          {% trans %}Please provide a brief summary of the purpose for your access. Account requests are analyzed on a case-by-case basis, and take typically 1 week to be processed.{% endtrans %}
         </p>
-  <form class="gray-surface" action="https://www.lib.uchicago.edu/cgi-bin/cgimail" method="POST">
+  <form class="gray-surface" action="https://www.lib.uchicago.edu/cgi-bin/cgimail" method="POST" style="max-width: 600px">
     <div class="row">
       <div class="col-xs-12">
         <input type="hidden" name="rcpt" value="{{cgimail.request_account.rcpt}}">

--- a/templates/sidebar-right.html
+++ b/templates/sidebar-right.html
@@ -50,7 +50,7 @@
                 <form action="https://www.lib.uchicago.edu/cgi-bin/cgimail" method="POST">
                   <input type="hidden" name="rcpt" value="{{cgimail.request_access.rcpt}}">
                   {# <input type="hidden" name="whom" value="MLC website"> #}
-                  <input type="hidden" name="from" value="MLC website">
+                  <input type="hidden" name="from" value="{{cgimail.default.from}}">
                   {# <input type="hidden" name="vrfy" value="trivial"> #}
                   <input type="hidden" name="subject" value="{{cgimail.request_access.surrogate}}">
                   <input type="hidden" name="CNET ID" value="{{ cnet_id }}" required>
@@ -81,7 +81,7 @@
           1-773-834-3181
         </p>
       </div>
-      <div class="collections access"> <!-- Feedback -->
+      <div class="collections feedback"> <!-- Feedback -->
         <h2>{% trans %}Feedback{% endtrans %}</h2>
         <!-- <p>Report errors, omissions, or other issues in the description of this collection.</p> -->
         {% set ts = "ittt=" ~ title_slug if title_slug else "" %}

--- a/templates/suggest-corrections.html
+++ b/templates/suggest-corrections.html
@@ -8,12 +8,10 @@
   <form id="suggestCorrections" class="gray-surface" action="https://www.lib.uchicago.edu/cgi-bin/cgimail" method="POST">
     <div class="row">
       <div class="col-xs-12">
-
-
   <form class="gray-surface" action="https://www.lib.uchicago.edu/cgi-bin/cgimail" method="POST">
     <input type="hidden" name="rcpt" value="{{cgimail.feedback.rcpt}}">
     {# <input type="hidden" name="whom" value="MLC website"> #}
-    <input type="hidden" name="from" value="MLC website">
+    <input type="hidden" id="cgimailfrom" name="from" value="{{cgimail.default.from}}">
     {# <input type="hidden" name="vrfy" value="trivial"> #}
     <input type="hidden" name="subject" value="{{cgimail.feedback.subject}}">
     <div class="row">
@@ -42,7 +40,7 @@
           </div>
           <div class="form-group">
             <label for="scEmail">{% trans %}Email address{% endtrans %}*</label>
-            <input type="email" class="form-control" id="scEmail" name="User's Email" placeholder="{% trans %}Enter your email address{% endtrans %}" required>
+            <input type="email" class="form-control" id="scEmail" name="User's Email" placeholder="{% trans %}Enter your email address{% endtrans %}" onchange="document.getElementById('cgimailfrom').value =(this.value)" required>
           </div>
           <div class="form-group">
             <label for="scSuggestions">{% trans %}Problems, comments, questions, or suggestions{% endtrans %}*</label>


### PR DESCRIPTION
- added an 'onchange' event that copies the user email in forms to show in the libAnswers message both as the 'from' email as a label:value pair;
- added my email as a default for the 'from' field. Needs a better default. Controlled through `app.py`.
- improved contextual copywrite.